### PR TITLE
#8 Add kafka component into hadoop-testing

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -83,3 +83,16 @@ services:
       - ./files/var/lib/grafana/dashboards:/var/lib/grafana/dashboards
     ports:
       - 3000:3000
+
+  kafka:
+    image: bitnami/kafka:2.8.1
+    hostname: kafka.orb.local
+    container_name: kafkabroker
+    ports:
+      - 9092:9092
+    environment:
+      - KAFKA_ZOOKEEPER_CONNECT=hadoop-master1.orb.local:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+    depends_on:
+      - hadoop-master1
+


### PR DESCRIPTION
how to verify the kafka service:

enter the kafka docker container, then producer message to topic `test`

```
./kafka-console-producer.sh --broker-list localhost:9092 --topic test
```

start another shell window, enter the kafka docker container, then consume messages from the topic `test`:

```
./kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic test --from-beginning
```