### PR TITLE
Include kdc in docker compose

### DIFF
--- a/host_vars/local.yaml
+++ b/host_vars/local.yaml
@@ -17,7 +17,7 @@ aws_java_sdk_include: true
 aws_java_sdk_version: 1.12.620
 
 # components
-kdc_include: false
+kerberos_enabled: false
 
 hadoop_include: true
 hadoop_version: 3.3.6

--- a/host_vars/local.yaml
+++ b/host_vars/local.yaml
@@ -17,6 +17,8 @@ aws_java_sdk_include: true
 aws_java_sdk_version: 1.12.620
 
 # components
+kdc_include: false
+
 hadoop_include: true
 hadoop_version: 3.3.6
 

--- a/kdc/files/etc/krb5.conf
+++ b/kdc/files/etc/krb5.conf
@@ -12,10 +12,10 @@
 
 [realms]
  TEST.ORG = {
-  kdc = kdc:88
-  admin_server = kdc
+  kdc = kdc.orb.local:88
+  admin_server = kdc.orb.local
  }
  OTHER.ORG = {
-  kdc = kdc:89
-  admin_server = kdc
+  kdc = kdc.orb.local:89
+  admin_server = kdc.orb.local
  }

--- a/templates/compose.yaml.j2
+++ b/templates/compose.yaml.j2
@@ -58,8 +58,6 @@ services:
     image: hadoop-testing/kdc:${PROJECT_VERSION}
     hostname: kdc.orb.local
     container_name: kdc
-    volumes:
-      - ./files/etc/prometheus:/etc/prometheus
     ports:
       - 88:88
       - 89:89

--- a/templates/compose.yaml.j2
+++ b/templates/compose.yaml.j2
@@ -53,6 +53,18 @@ services:
     depends_on:
       - hadoop-master1
 
+{% if kdc_include %}
+  kdc:
+    image: hadoop-testing/kdc:${PROJECT_VERSION}
+    hostname: kdc.orb.local
+    container_name: kdc
+    volumes:
+      - ./files/etc/prometheus:/etc/prometheus
+    ports:
+      - 88:88
+      - 89:89
+{% endif %}
+
 {% if prometheus_include %}
   prometheus:
     image: prom/prometheus

--- a/templates/compose.yaml.j2
+++ b/templates/compose.yaml.j2
@@ -53,7 +53,7 @@ services:
     depends_on:
       - hadoop-master1
 
-{% if kdc_include %}
+{% if kerberos_enabled %}
   kdc:
     image: hadoop-testing/kdc:${PROJECT_VERSION}
     hostname: kdc.orb.local


### PR DESCRIPTION
Include kdc in docker compose. 

It will be used to setup a kerberized hadoop cluster.