### PR TITLE
Use LinuxContainerExecutor with kerberized YARN

### DIFF
--- a/base-ubuntu-2204/Dockerfile
+++ b/base-ubuntu-2204/Dockerfile
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 ARG JDK8_TAR_NAME
 ARG JDK17_TAR_NAME
@@ -20,7 +20,8 @@ COPY ./files /
 
 RUN set -xeu && \
     ln -snf /usr/bin/bash /usr/bin/sh && \
-    install_packages busybox python3-pip supervisor xsltproc curl tree python-is-python3 openssh-client openssh-server krb5-user jsvc && \
+    install_packages busybox python3-pip supervisor xsltproc curl tree python-is-python3 openssh-client openssh-server \
+    krb5-user jsvc libssl1.1 && \
     mkdir /run/sshd && chmod 0755 /run/sshd && \
     mkdir /opt/busybox && busybox --install /opt/busybox
 

--- a/build-image.sh
+++ b/build-image.sh
@@ -38,7 +38,7 @@ ${BUILD_CMD} \
   --build-arg JDK8_TAR_NAME=${JDK8_TAR_NAME} \
   --build-arg JDK17_TAR_NAME=${JDK17_TAR_NAME} \
   --build-arg JDK21_TAR_NAME=${JDK21_TAR_NAME} \
-  --tag hadoop-testing/base-ubuntu-2204:${PROJECT_VERSION} \
+  --tag hadoop-testing/base-ubuntu-2004:${PROJECT_VERSION} \
   "${SELF_DIR}/base-ubuntu-2204" $@
 
 rm -rf base-ubuntu-2204/download/*

--- a/kdc/Dockerfile
+++ b/kdc/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 ARG PROJECT_VERSION
-FROM hadoop-testing/base-ubuntu-2204:$PROJECT_VERSION
+FROM hadoop-testing/base-ubuntu-2004:$PROJECT_VERSION
 
 # COPY CONFIGURATION
 COPY ./files /

--- a/kdc/files/etc/krb5kdc/kdc.conf
+++ b/kdc/files/etc/krb5kdc/kdc.conf
@@ -7,14 +7,12 @@
   acl_file = /etc/krb5kdc/kadm5.acl
   dict_file = /usr/share/dict/words
   admin_keytab = /etc/krb5kdc/kadm5.keytab
-  supported_enctypes = aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal des-hmac-sha1:normal des-cbc-md5:normal des-cbc-crc:normal
  }
 
  OTHER.ORG = {
   acl_file = /etc/krb5kdc/kadm5-other.acl
   dict_file = /usr/share/dict/words
   admin_keytab = /etc/krb5kdc/kadm5-other.keytab
-  supported_enctypes = aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal des-hmac-sha1:normal des-cbc-md5:normal des-cbc-crc:normal
   kdc_listen = 89
   kdc_tcp_listen = 89
   kdc_ports = 89

--- a/templates/hadoop-common/files/etc/hadoop/conf/container-executor.cfg
+++ b/templates/hadoop-common/files/etc/hadoop/conf/container-executor.cfg
@@ -1,0 +1,5 @@
+yarn.nodemanager.linux-container-executor.group=hadoop#configured value of yarn.nodemanager.linux-container-executor.group
+banned.users=#comma separated list of users who can not run applications
+min.user.id=1000#Prevent other super-users
+allowed.system.users=##comma separated list of system users who CAN run applications
+feature.tc.enabled=false

--- a/templates/hadoop-common/files/etc/hadoop/conf/yarn-site.xml
+++ b/templates/hadoop-common/files/etc/hadoop/conf/yarn-site.xml
@@ -20,6 +20,14 @@
     <name>yarn.nodemanager.keytab</name>
     <value>/share/keytabs/{{ node.name }}/nm.service.keytab</value>
   </property>
+  <property>
+    <name>yarn.nodemanager.container-executor.class</name>
+    <value>org.apache.hadoop.yarn.server.nodemanager.LinuxContainerExecutor</value>
+  </property>
+  <property>
+    <name>yarn.nodemanager.linux-container-executor.group</name>
+    <value>hadoop</value>
+  </property>
   {% endif %}
   <property>
     <name>yarn.resourcemanager.address</name>

--- a/templates/hadoop-common/files/opt/hadoop-init.d/init-hdfs.sh
+++ b/templates/hadoop-common/files/opt/hadoop-init.d/init-hdfs.sh
@@ -13,7 +13,8 @@ mkdir /opt/hadoop/logs /var/log/hadoop-hdfs /var/log/hadoop-yarn
 chown -R hadoop.hadoop /opt/hadoop/logs
 chown -R hdfs.hadoop /var/log/hadoop-hdfs
 chown -R yarn.hadoop /var/log/hadoop-yarn
-chmod -R 770 /opt/hadoop/logs /var/log/hadoop-hdfs /var/log/hadoop-yarn
+chmod -R 770 /opt/hadoop/logs /var/log/hadoop-hdfs
+chmod 755 /var/log/hadoop-yarn
 
 # workaround for 'could not open session' bug as suggested here:
 # https://github.com/docker/docker/issues/7056#issuecomment-49371610

--- a/templates/hadoop-master/Dockerfile
+++ b/templates/hadoop-master/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 ARG PROJECT_VERSION
-FROM hadoop-testing/base-ubuntu-2204:$PROJECT_VERSION
+FROM hadoop-testing/base-ubuntu-2004:$PROJECT_VERSION
 
 ARG ZOOKEEPER_VERSION
 ARG HADOOP_VERSION

--- a/templates/hadoop-master/files/opt/hadoop-init.d/init-hdfs.sh
+++ b/templates/hadoop-master/files/opt/hadoop-init.d/init-hdfs.sh
@@ -22,7 +22,8 @@ mkdir /opt/hadoop/logs /var/log/hadoop-hdfs /var/log/hadoop-yarn
 chown -R hadoop.hadoop /opt/hadoop/logs
 chown -R hdfs.hadoop /var/log/hadoop-hdfs
 chown -R yarn.hadoop /var/log/hadoop-yarn
-chmod -R 770 /opt/hadoop/logs /var/log/hadoop-hdfs /var/log/hadoop-yarn
+chmod -R 770 /opt/hadoop/logs /var/log/hadoop-hdfs
+chmod -R 755 /var/log/hadoop-yarn
 
 touch /var/log/hdfs-namenode.log
 chown hdfs /var/log/hdfs-namenode.log

--- a/templates/hadoop-worker/Dockerfile
+++ b/templates/hadoop-worker/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 ARG PROJECT_VERSION
-FROM hadoop-testing/base-ubuntu-2204:$PROJECT_VERSION
+FROM hadoop-testing/base-ubuntu-2004:$PROJECT_VERSION
 
 ARG HADOOP_VERSION
 ARG SPARK_VERSION
@@ -33,6 +33,12 @@ COPY ./files /
 RUN ln -snf /opt/hadoop-${HADOOP_VERSION} ${HADOOP_HOME} && \
     ln -snf spark-${SPARK_VERSION}-bin-hadoop3 /opt/spark && \
     ln -snf /opt/trino-server-${TRINO_VERSION} ${TRINO_HOME}
+
+RUN chown -R root:hadoop /opt/hadoop-${HADOOP_VERSION} && \
+    chmod 6050 /opt/hadoop-${HADOOP_VERSION}/bin/container-executor && \
+    chown root:hadoop /etc/hadoop/conf/container-executor.cfg && \
+    chmod 0400 /etc/hadoop/conf/container-executor.cfg && \
+    mv -f /etc/hadoop/conf/container-executor.cfg /opt/hadoop-${HADOOP_VERSION}/etc/hadoop
 
 RUN /opt/hadoop-init.d/init-hdfs.sh
 RUN /opt/trino-init.d/init-workdir.sh


### PR DESCRIPTION
Without using LinuxContainerExecutor, container logs are not accessible through Job History Server.