### PR TITLE
Change hive.txn.manager to DummyTxnManager

### DIFF
--- a/templates/hadoop-master/files/etc/hive/conf/hive-site.xml.j2
+++ b/templates/hadoop-master/files/etc/hive/conf/hive-site.xml.j2
@@ -89,7 +89,7 @@
   </property>
   <property>
     <name>hive.txn.manager</name>
-    <value>org.apache.hadoop.hive.ql.lockmgr.DbTxnManager</value>
+    <value>org.apache.hadoop.hive.ql.lockmgr.DummyTxnManager</value>
   </property>
   <property>
     <name>hive.compactor.initiator.on</name>


### PR DESCRIPTION
Current `hive.txn.manager` is `org.apache.hadoop.hive.ql.lockmgr.DummyTxnManager`.
If Kyuubi's HiveSQLEngine crashed and restarted, following queries may wait for Table lock for a long time until last lock is expired.