### PR TITLE
Install sqlite3 in base image

### DIFF
--- a/templates/base-ubuntu-2004/Dockerfile.j2
+++ b/templates/base-ubuntu-2004/Dockerfile.j2
@@ -24,7 +24,8 @@ RUN cat /etc/apt/sources.list.mirror-$(uname -m) > /etc/apt/sources.list
 
 RUN set -xeu && \
     ln -snf /usr/bin/bash /usr/bin/sh && \
-    install_packages busybox python3-pip supervisor xsltproc curl tree python-is-python3 openssh-client openssh-server \
+    install_packages busybox python3-pip supervisor xsltproc curl tree python-is-python3 \
+    openssh-client openssh-server sqlite3 \
     {% if kerberos_enabled %}krb5-user jsvc libssl1.1{% endif %} && \
     mkdir /run/sshd && chmod 0755 /run/sshd && \
     mkdir /opt/busybox && busybox --install /opt/busybox


### PR DESCRIPTION
Kyuubi uses sqlite3 to store the metadata for batch jobs by default, installing sqlite3 allows to access the DB file from cli

```
$ sqlite3 --help
Usage: sqlite3 [OPTIONS] [FILENAME [SQL]]
FILENAME is the name of an SQLite database. A new database is created
if the file does not previously exist. Defaults to :memory:.
OPTIONS include:
...
```