### PR TITLE
Change Kyuubi Spark deploy mode to cluster

### DIFF
--- a/templates/hadoop-master/files/etc/kyuubi/conf/kyuubi-defaults.conf.j2
+++ b/templates/hadoop-master/files/etc/kyuubi/conf/kyuubi-defaults.conf.j2
@@ -40,7 +40,8 @@ kyuubi.engine.session.initialize.sql \
       show databases in tpcds; \
       show databases in tpch
 
-spark.yarn.maxAppAttempts                1
-spark.submit.deployMode                  cluster
+spark.yarn.maxAppAttempts                    1
+spark.submit.deployMode                      cluster
+kyuubi.session.engine.startup.waitCompletion false
 
 # Details in https://kyuubi.readthedocs.io/en/master/configuration/settings.html

--- a/templates/hadoop-master/files/etc/kyuubi/conf/kyuubi-defaults.conf.j2
+++ b/templates/hadoop-master/files/etc/kyuubi/conf/kyuubi-defaults.conf.j2
@@ -41,5 +41,6 @@ kyuubi.engine.session.initialize.sql \
       show databases in tpch
 
 spark.yarn.maxAppAttempts                1
+spark.submit.deployMode                  cluster
 
 # Details in https://kyuubi.readthedocs.io/en/master/configuration/settings.html


### PR DESCRIPTION
Because `spark-sql`, `spark-shell` do not support cluster mode, we reserve `spark.submit.deployMode=client` in `spark-defaults.conf` to make those Spark commands usage out-of-box. While Kyuubi supports cluster mode, and we should use it by default.