### PR TITLE
loki log4j should use daemon thread and respect loki_enabled

### DIFF
--- a/host_vars/local.yaml
+++ b/host_vars/local.yaml
@@ -65,7 +65,7 @@ prometheus_enabled: false
 
 loki_enabled: false
 loki_version: 2.8.0
-loki_log4j2_appender_version: 0.9.17
+loki_log4j2_appender_version: 0.9.32
 
 mysql_enabled: true
 

--- a/templates/hadoop-master/files/etc/spark/conf/log4j2.xml.j2
+++ b/templates/hadoop-master/files/etc/spark/conf/log4j2.xml.j2
@@ -4,6 +4,7 @@
     <Console name="stdout" target="SYSTEM_OUT">
       <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %p %c{1}: %m%n"/>
     </Console>
+    {% if loki_enabled %}
     <Loki name="loki">
       <host>loki</host>
       <port>3100</port>
@@ -11,16 +12,22 @@
         <Pattern>%X{tid} [%t] %d{yyyy-MM-dd HH:mm:ss.SSS} %5p %c{1} - %m%n%exception{full}</Pattern>
       </PatternLayout>
       <Label name="host" value="${sys:hostname}"/>
+      <useDaemonThreads>true</useDaemonThreads>
     </Loki>
+    {% endif %}
   </Appenders>
   <Loggers>
     <Root level="INFO">
       <AppenderRef ref="stdout"/>
+      {% if loki_enabled %}
       <AppenderRef ref="loki"/>
+      {% endif %}
     </Root>
     <Logger name="org.apache.hadoop.util.Shell" level="ERROR" additivity="false">
       <AppenderRef ref="stdout"/>
+      {% if loki_enabled %}
       <AppenderRef ref="loki"/>
+      {% endif %}
     </Logger>
   </Loggers>
 </Configuration>


### PR DESCRIPTION
The log4j-loki-appender added `useDaemonThreads` flag in 0.9.28

https://github.com/tkowalcz/tjahzi/releases/tag/tjahzi-parent-0.9.28