### PR TITLE
Enable EmbeddedLockManager on HS2 to support concurrency 

### DIFF
--- a/templates/hadoop-master/files/etc/hive/conf/hive-site.xml.j2
+++ b/templates/hadoop-master/files/etc/hive/conf/hive-site.xml.j2
@@ -92,6 +92,10 @@
     <value>org.apache.hadoop.hive.ql.lockmgr.DummyTxnManager</value>
   </property>
   <property>
+    <name>hive.lock.manager</name>
+    <value>org.apache.hadoop.hive.ql.lockmgr.EmbeddedLockManager</value>
+  </property>
+  <property>
     <name>hive.compactor.initiator.on</name>
     <value>true</value>
   </property>


### PR DESCRIPTION
By default, hive.support.concurrency is true and DummyTxnManager requires a ZooKeeper quorum.