### PR TITLE
Respect flink_enabled

### DIFF
--- a/templates/build-image.sh.j2
+++ b/templates/build-image.sh.j2
@@ -75,7 +75,9 @@ function build_hadoop_master_image() {
   cp download/${HADOOP_TAR_NAME}.tar.gz hadoop-master${INDEX}/download/hadoop-${HADOOP_VERSION}.tar.gz
   cp download/apache-hive-${HIVE_VERSION}-bin.tar.gz hadoop-master${INDEX}/download/apache-hive-${HIVE_VERSION}-bin.tar.gz
   cp download/spark-${SPARK_VERSION}-bin-hadoop3.tgz hadoop-master${INDEX}/download/spark-${SPARK_VERSION}-bin-hadoop3.tgz
+  {% if flink_enabled %}
   cp download/flink-${FLINK_VERSION}-bin-scala_${SCALA_BINARY_VERSION}.tgz hadoop-master${INDEX}/download/flink-${FLINK_VERSION}-bin-scala_${SCALA_BINARY_VERSION}.tgz
+  {% endif %}
   cp download/apache-kyuubi-${KYUUBI_VERSION}-bin.tgz hadoop-master${INDEX}/download/apache-kyuubi-${KYUUBI_VERSION}-bin.tgz
   {% if ranger_enabled %}
   cp download/ranger-${RANGER_VERSION}-admin.tar.gz hadoop-master${INDEX}/download/ranger-${RANGER_VERSION}-admin.tar.gz

--- a/templates/hadoop-master/Dockerfile.j2
+++ b/templates/hadoop-master/Dockerfile.j2
@@ -40,8 +40,10 @@ ENV HIVE_HOME=/opt/hive
 ENV HIVE_CONF_DIR=/etc/hive/conf
 ENV SPARK_HOME=/opt/spark
 ENV SPARK_CONF_DIR=/etc/spark/conf
+{% if flink_enabled %}
 ENV FLINK_HOME=/opt/flink
 ENV FLINK_CONF_DIR=/etc/flink/conf
+{% endif %}
 ENV KYUUBI_HOME=/opt/kyuubi
 ENV KYUUBI_CONF_DIR=/etc/kyuubi/conf
 {% if ranger_enabled %}
@@ -60,7 +62,9 @@ ADD download/apache-zookeeper-${ZOOKEEPER_VERSION}-bin.tar.gz /opt
 ADD download/hadoop-${HADOOP_VERSION}.tar.gz /opt
 ADD download/apache-hive-${HIVE_VERSION}-bin.tar.gz /opt
 ADD download/spark-${SPARK_VERSION}-bin-hadoop3.tgz /opt
+{% if flink_enabled %}
 ADD download/flink-${FLINK_VERSION}-bin-scala_${SCALA_BINARY_VERSION}.tgz /opt
+{% endif %}
 ADD download/apache-kyuubi-${KYUUBI_VERSION}-bin.tgz /opt
 {% if ranger_enabled %}
 ADD download/ranger-${RANGER_VERSION}-admin.tar.gz /opt
@@ -81,8 +85,11 @@ RUN ln -snf /opt/apache-zookeeper-${ZOOKEEPER_VERSION}-bin ${ZOOKEEPER_HOME} && 
     ln -snf /opt/hadoop-${HADOOP_VERSION} ${HADOOP_HOME} && \
     ln -snf /opt/apache-hive-${HIVE_VERSION}-bin ${HIVE_HOME} && \
     ln -snf /opt/spark-${SPARK_VERSION}-bin-hadoop3 ${SPARK_HOME} && \
-    ln -snf /opt/flink-${FLINK_VERSION} ${FLINK_HOME} && \
     ln -snf /opt/apache-kyuubi-${KYUUBI_VERSION}-bin ${KYUUBI_HOME}
+
+{% if flink_enabled %}
+RUN ln -snf /opt/flink-${FLINK_VERSION} ${FLINK_HOME}
+{% endif %}
 
 {% if zeppelin_enabled %}
 RUN ln -snf /opt/zeppelin-${ZEPPELIN_VERSION}-bin-netinst ${ZEPPELIN_HOME} && \


### PR DESCRIPTION
As title.

Before this PR, when disabled flink, we won't download flink binary package, but we still build hadoop master with flink. This will cause error.

After this PR, we won't build image with flink in case of disabled flink.