### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Firstly, use ansible to render some build files(`download.sh`, `.env`, `compose.
 ```
 ansible-playbook playbook.yaml
 ```
-Ensure you specify the inventory file when running the playbook if it is not located in the default path or correctly recognized by Ansible. For instance, use `ansible-playbook -i your_inventory_file playbook.yaml` to explicitly define the inventory.
+Ensure you specify the inventory file when running the playbook if it is not located in the default path or correctly recognized by Ansible. For instance, use `ansible-playbook -i hosts playbook.yaml` to explicitly define the inventory.
 
 By default, all services disable authN, you can enable Kerberos by passing the `kerberos_enabled` variable:
 ```

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Firstly, use ansible to render some build files(`download.sh`, `.env`, `compose.
 ```
 ansible-playbook playbook.yaml
 ```
+Ensure you specify the inventory file when running the playbook if it is not located in the default path or correctly recognized by Ansible. For instance, use `ansible-playbook -i your_inventory_file playbook.yaml` to explicitly define the inventory.
 
 By default, all services disable authN, you can enable Kerberos by passing the `kerberos_enabled` variable:
 ```


### PR DESCRIPTION
Ensure you specify the inventory file when running the playbook if it is not located in the default path or correctly recognized by Ansible. For instance, use `ansible-playbook -i your_inventory_file playbook.yaml` to explicitly define the inventory.