### PR TITLE
Remove the duplicated FLINK_BINARY_VERSION in the templates/.env.j2 file and fix bug

### DIFF
--- a/host_vars/local.yaml
+++ b/host_vars/local.yaml
@@ -39,7 +39,7 @@ spark_version: 3.5.2
 spark_custom_name: hadoop3
 
 flink_enabled: false
-flink_binary_version: 1.20
+flink_binary_version: '1.20'
 flink_version: 1.20.0
 flink_hive_version: 2.3.10
 

--- a/templates/.env.j2
+++ b/templates/.env.j2
@@ -24,7 +24,6 @@ SPARK_BINARY_VERSION={{ spark_binary_version }}
 SPARK_HADOOP_VERSION={{ spark_hadoop_version }}
 FLINK_BINARY_VERSION={{ flink_binary_version }}
 FLINK_VERSION={{ flink_version }}
-FLINK_BINARY_VERSION={{ flink_binary_version }}
 FLINK_HIVE_VERSION={{ flink_hive_version }}
 ZEPPELIN_VERSION={{ zeppelin_version }}
 ZOOKEEPER_VERSION={{ zookeeper_version }}


### PR DESCRIPTION
Remove the duplicated FLINK_BINARY_VERSION in the templates/.env.j2 file.

Fix the bug where flink_binary_version: 1.20 in host_vars/local.yaml results in FLINK_BINARY_VERSION=1.2 in the .env file, which is actually incorrect.

- incorrect result:
![incorrect result](https://github.com/user-attachments/assets/b58f2ea4-df8b-445a-b9e7-f24e18fbd440)
- fixed result:
![fixed result](https://github.com/user-attachments/assets/bd2a0b7f-e344-4e37-bbdc-7b80bc965d57)

This will cause the download link generated by my `download.sh` script to be `https://xxx/maven/org/apache/iceberg/iceberg-flink-runtime-1.2/1.7.0/iceberg-flink-runtime-1.2-1.7.0.jar`, which does not exist. The actual correct link should be:
`https://xxx/maven/org/apache/iceberg/iceberg-flink-runtime-1.20/1.7.0/iceberg-flink-runtime-1.20-1.7.0.jar`