### PR TITLE
Disable Kyuubi progress bar

### DIFF
--- a/templates/hadoop-master/files/etc/kyuubi/conf/kyuubi-defaults.conf.j2
+++ b/templates/hadoop-master/files/etc/kyuubi/conf/kyuubi-defaults.conf.j2
@@ -38,7 +38,6 @@ kyuubi.ha.namespace                      kyuubi
 kyuubi.yarn.user.strategy  ADMIN
 kyuubi.yarn.user.admin     yarn
 
-kyuubi.operation.progress.enabled=true
 kyuubi.metadata.store.jdbc.database.schema.init=false
 kyuubi.metadata.store.jdbc.database.type=mysql
 kyuubi.metadata.store.jdbc.driver=com.mysql.jdbc.Driver


### PR DESCRIPTION
Disable this feature by default because sometimes the progress bar overwrites the result table.

cc @wForget 